### PR TITLE
Add new LLVM versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,8 @@ const VERSIONS = getVersions([
   "7.1.0",
   "8.0.0", "8.0.1",
   "9.0.0", "9.0.1",
-  "10.0.0",
+  "10.0.0", "10.0.1",
+  "11.0.0
 ]);
 
 function compareVersions(left, right) {
@@ -128,6 +129,8 @@ const UBUNTU = {
   "9.0.0": "-ubuntu-18.04",
   "9.0.1": "-ubuntu-16.04",
   "10.0.0": "-ubuntu-18.04",
+  "10.0.1": "-ubuntu-18.04",
+  "11.0.0": "-ubuntu-20.04"
 };
 
 function getLinuxUrl(version) {

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ const VERSIONS = getVersions([
   "8.0.0", "8.0.1",
   "9.0.0", "9.0.1",
   "10.0.0", "10.0.1",
-  "11.0.0
+  "11.0.0",
 ]);
 
 function compareVersions(left, right) {
@@ -130,7 +130,7 @@ const UBUNTU = {
   "9.0.1": "-ubuntu-16.04",
   "10.0.0": "-ubuntu-18.04",
   "10.0.1": "-ubuntu-18.04",
-  "11.0.0": "-ubuntu-20.04"
+  "11.0.0": "-ubuntu-20.04",
 };
 
 function getLinuxUrl(version) {


### PR DESCRIPTION
New versions were recently released: `10.0.1` & `11.0.0`. I would suggest adding an option to forcefully specify the version just so users don't have to wait until the hard-coded versions catch up, if there isn't one already.