### PR TITLE
Adds support up to LLVM 14.0.6

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -49,7 +49,7 @@ const VERSIONS: Set<string> = getVersions([
   "11.0.0", "11.0.1", "11.1.0",
   "12.0.0", "12.0.1",
   "13.0.0", "13.0.1",
-  "14.0.0"
+  "14.0.0", "14.0.1", "14.0.2", "14.0.3", "14.0.4", "14.0.5", "14.0.6"
 ]);
 
 /** Gets the ordering of two (specific or minimum) LLVM versions. */


### PR DESCRIPTION
I have no idea why you would ever write something like this that doesn't just support specifying a release version since it's literally just pasted into the URL but ok