### PR TITLE
Add test of installing clang-18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
           - windows-latest
         version:
           - 17
+          - 18
 
     runs-on: "${{ matrix.os }}"
 


### PR DESCRIPTION
[Release 2.0](https://github.com/KyleMayes/install-llvm-action/releases/tag/v2.0.0) says it "Added support for various missing LLVM and Clang versions up to 18.1.2"

I am however running into issues when trying to install it on github runners 'ubuntu-22.04' with error message:
```
Run KyleMayes/install-llvm-action@v2
hello
Checking known assets (os=linux, arch=x64, version=18)...
Error: Unsupported version for platform (os=linux, arch=x64, version=18)!
    at $73b874f14e970995$export$da446a5ee2572b7 (/home/runner/work/_actions/KyleMayes/install-llvm-action/v2/dist/main.js:7615:41)
    at $73b874f14e970995$var$install (/home/runner/work/_actions/KyleMayes/install-llvm-action/v2/dist/main.js:7633:60)
    at $73b874f14e970995$export$889ea624f2cb2c57 (/home/runner/work/_actions/KyleMayes/install-llvm-action/v2/dist/main.js:7663:16)
    at $933db609b41224a7$var$main (/home/runner/work/_actions/KyleMayes/install-llvm-action/v2/dist/main.js:7681:61)
Error: Unsupported version for platform (os=linux, arch=x64, version=18)!
    at Object.<anonymous> (/home/runner/work/_actions/KyleMayes/install-llvm-action/v2/dist/main.js:7688:1)
    at Module._compile (node:internal/modules/cjs/loader:1241:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1295:10)
    at Module.load (node:internal/modules/cjs/loader:1091:32)
    at Module._load (node:internal/modules/cjs/loader:938:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:83:12)
```

This PR adds clang-18 to the test matrix