### PR TITLE
chore: migrate to Node 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,5 +36,5 @@ outputs:
     description: "The full version of LLVM and Clang binaries installed."
 
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/main.js"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@octokit/rest": "^21",
     "@types/lodash": "^4",
-    "@types/node": "~20",
+    "@types/node": "~24",
     "json-stable-stringify": "^1",
     "lodash": "^4",
     "parcel": "^2",
@@ -30,7 +30,7 @@
   "targets": {
     "main": {
       "context": "node",
-      "engines": { "node": "20" },
+      "engines": { "node": "24" },
       "includeNodeModules": true
     }
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
     "esModuleInterop": true,
-    "lib": ["ES2023"],
+    "lib": ["ES2025"],
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "strict": true,
-    "target": "ES2018"
+    "target": "ES2024"
   },
   "files": ["./generate.ts", "./index.ts", "./test.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1098,12 +1098,12 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.20.tgz#1ca77361d7363432d29f5e55950d9ec1e1c6ea93"
   integrity sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==
 
-"@types/node@~20":
-  version "20.19.19"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.19.19.tgz#18c8982becd5728f92e5f1939f2f3dc85604abcd"
-  integrity sha512-pb1Uqj5WJP7wrcbLU7Ru4QtA0+3kAXrkutGiD26wUKzSMgNNaPARTUDQmElUXp64kh3cWdou3Q0C7qwwxqSFmg==
+"@types/node@~24":
+  version "24.12.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.12.0.tgz#6222e028210e5322e4f4f6767f8d88e5ea3b33d2"
+  integrity sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==
   dependencies:
-    undici-types "~6.21.0"
+    undici-types "~7.16.0"
 
 acorn-walk@^8.1.1:
   version "8.3.4"
@@ -1743,10 +1743,10 @@ typescript@^5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
-undici-types@~6.21.0:
-  version "6.21.0"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
-  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
+undici-types@~7.16.0:
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.16.0.tgz#ffccdff36aea4884cbfce9a750a0580224f58a46"
+  integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
 
 undici@^5.25.4:
   version "5.29.0"


### PR DESCRIPTION
Update GitHub Actions runtime from node20 to node24.
Bump @types/node, engines, and TypeScript target/lib accordingly.