### PR TITLE
Add support for LLVM 22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.0.10] - UNRELEASED
+
+- Added support for LLVM and Clang 22
+
 ## [2.0.9] - 2026-01-20
 
 - Added support for additional LLVM and Clang 20/21 versions

--- a/assets.json
+++ b/assets.json
@@ -38,7 +38,12 @@
       "20.1.7": "/LLVM-20.1.7-macOS-ARM64.tar.xz",
       "20.1.8": "/LLVM-20.1.8-macOS-ARM64.tar.xz",
       "21.1.6": "/LLVM-21.1.6-macOS-ARM64.tar.xz",
-      "21.1.8": "/LLVM-21.1.8-macOS-ARM64.tar.xz"
+      "21.1.8": "/LLVM-21.1.8-macOS-ARM64.tar.xz",
+      "22.1.0": "/LLVM-22.1.0-macOS-ARM64.tar.xz",
+      "22.1.1": "/LLVM-22.1.1-macOS-ARM64.tar.xz",
+      "22.1.2": "/LLVM-22.1.2-macOS-ARM64.tar.xz",
+      "22.1.3": "/LLVM-22.1.3-macOS-ARM64.tar.xz",
+      "22.1.4": "/LLVM-22.1.4-macOS-ARM64.tar.xz"
     },
     "x64": {
       "9.0.1": "/clang%2Bllvm-9.0.1-x86_64-apple-darwin.tar.xz",
@@ -144,7 +149,12 @@
       "21.1.5": "/LLVM-21.1.5-Linux-ARM64.tar.xz",
       "21.1.6": "/LLVM-21.1.6-Linux-ARM64.tar.xz",
       "21.1.7": "/LLVM-21.1.7-Linux-ARM64.tar.xz",
-      "21.1.8": "/LLVM-21.1.8-Linux-ARM64.tar.xz"
+      "21.1.8": "/LLVM-21.1.8-Linux-ARM64.tar.xz",
+      "22.1.0": "/LLVM-22.1.0-Linux-ARM64.tar.xz",
+      "22.1.1": "/LLVM-22.1.1-Linux-ARM64.tar.xz",
+      "22.1.2": "/LLVM-22.1.2-Linux-ARM64.tar.xz",
+      "22.1.3": "/LLVM-22.1.3-Linux-ARM64.tar.xz",
+      "22.1.4": "/LLVM-22.1.4-Linux-ARM64.tar.xz"
     },
     "x64": {
       "7.1.0": "/clang%2Bllvm-7.1.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz",
@@ -198,7 +208,12 @@
       "21.1.5": "/LLVM-21.1.5-Linux-X64.tar.xz",
       "21.1.6": "/LLVM-21.1.6-Linux-X64.tar.xz",
       "21.1.7": "/LLVM-21.1.7-Linux-X64.tar.xz",
-      "21.1.8": "/LLVM-21.1.8-Linux-X64.tar.xz"
+      "21.1.8": "/LLVM-21.1.8-Linux-X64.tar.xz",
+      "22.1.0": "/LLVM-22.1.0-Linux-X64.tar.xz",
+      "22.1.1": "/LLVM-22.1.1-Linux-X64.tar.xz",
+      "22.1.2": "/LLVM-22.1.2-Linux-X64.tar.xz",
+      "22.1.3": "/LLVM-22.1.3-Linux-X64.tar.xz",
+      "22.1.4": "/LLVM-22.1.4-Linux-X64.tar.xz"
     }
   },
   "win32": {
@@ -256,7 +271,12 @@
       "21.1.5": "/LLVM-21.1.5-woa64.exe",
       "21.1.6": "/LLVM-21.1.6-woa64.exe",
       "21.1.7": "/LLVM-21.1.7-woa64.exe",
-      "21.1.8": "/LLVM-21.1.8-woa64.exe"
+      "21.1.8": "/LLVM-21.1.8-woa64.exe",
+      "22.1.0": "/LLVM-22.1.0-woa64.exe",
+      "22.1.1": "/LLVM-22.1.1-woa64.exe",
+      "22.1.2": "/LLVM-22.1.2-woa64.exe",
+      "22.1.3": "/LLVM-22.1.3-woa64.exe",
+      "22.1.4": "/LLVM-22.1.4-woa64.exe"
     },
     "x64": {
       "7.1.0": "/LLVM-7.1.0-win64.exe",
@@ -332,7 +352,12 @@
       "21.1.5": "/LLVM-21.1.5-win64.exe",
       "21.1.6": "/LLVM-21.1.6-win64.exe",
       "21.1.7": "/LLVM-21.1.7-win64.exe",
-      "21.1.8": "/LLVM-21.1.8-win64.exe"
+      "21.1.8": "/LLVM-21.1.8-win64.exe",
+      "22.1.0": "/LLVM-22.1.0-win64.exe",
+      "22.1.1": "/LLVM-22.1.1-win64.exe",
+      "22.1.2": "/LLVM-22.1.2-win64.exe",
+      "22.1.3": "/LLVM-22.1.3-win64.exe",
+      "22.1.4": "/LLVM-22.1.4-win64.exe"
     }
   }
 }

--- a/assets.json
+++ b/assets.json
@@ -43,7 +43,11 @@
       "22.1.1": "/LLVM-22.1.1-macOS-ARM64.tar.xz",
       "22.1.2": "/LLVM-22.1.2-macOS-ARM64.tar.xz",
       "22.1.3": "/LLVM-22.1.3-macOS-ARM64.tar.xz",
-      "22.1.4": "/LLVM-22.1.4-macOS-ARM64.tar.xz"
+      "22.1.4": "/LLVM-22.1.4-macOS-ARM64.tar.xz",
+      "22.1.5": "/LLVM-22.1.5-macOS-ARM64.tar.xz",
+      "22.1.6": "/LLVM-22.1.6-macOS-ARM64.tar.xz",
+      "22.1.7": "/LLVM-22.1.7-macOS-ARM64.tar.xz",
+      "22.1.8": "/LLVM-22.1.8-macOS-ARM64.tar.xz"
     },
     "x64": {
       "9.0.1": "/clang%2Bllvm-9.0.1-x86_64-apple-darwin.tar.xz",
@@ -154,7 +158,11 @@
       "22.1.1": "/LLVM-22.1.1-Linux-ARM64.tar.xz",
       "22.1.2": "/LLVM-22.1.2-Linux-ARM64.tar.xz",
       "22.1.3": "/LLVM-22.1.3-Linux-ARM64.tar.xz",
-      "22.1.4": "/LLVM-22.1.4-Linux-ARM64.tar.xz"
+      "22.1.4": "/LLVM-22.1.4-Linux-ARM64.tar.xz",
+      "22.1.5": "/LLVM-22.1.5-Linux-ARM64.tar.xz",
+      "22.1.6": "/LLVM-22.1.6-Linux-ARM64.tar.xz",
+      "22.1.7": "/LLVM-22.1.7-Linux-ARM64.tar.xz",
+      "22.1.8": "/LLVM-22.1.8-Linux-ARM64.tar.xz"
     },
     "x64": {
       "7.1.0": "/clang%2Bllvm-7.1.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz",
@@ -213,7 +221,11 @@
       "22.1.1": "/LLVM-22.1.1-Linux-X64.tar.xz",
       "22.1.2": "/LLVM-22.1.2-Linux-X64.tar.xz",
       "22.1.3": "/LLVM-22.1.3-Linux-X64.tar.xz",
-      "22.1.4": "/LLVM-22.1.4-Linux-X64.tar.xz"
+      "22.1.4": "/LLVM-22.1.4-Linux-X64.tar.xz",
+      "22.1.5": "/LLVM-22.1.5-Linux-X64.tar.xz",
+      "22.1.6": "/LLVM-22.1.6-Linux-X64.tar.xz",
+      "22.1.7": "/LLVM-22.1.7-Linux-X64.tar.xz",
+      "22.1.8": "/LLVM-22.1.8-Linux-X64.tar.xz"
     }
   },
   "win32": {
@@ -276,7 +288,11 @@
       "22.1.1": "/LLVM-22.1.1-woa64.exe",
       "22.1.2": "/LLVM-22.1.2-woa64.exe",
       "22.1.3": "/LLVM-22.1.3-woa64.exe",
-      "22.1.4": "/LLVM-22.1.4-woa64.exe"
+      "22.1.4": "/LLVM-22.1.4-woa64.exe",
+      "22.1.5": "/LLVM-22.1.5-woa64.exe",
+      "22.1.6": "/LLVM-22.1.6-woa64.exe",
+      "22.1.7": "/LLVM-22.1.7-woa64.exe",
+      "22.1.8": "/LLVM-22.1.8-woa64.exe"
     },
     "x64": {
       "7.1.0": "/LLVM-7.1.0-win64.exe",
@@ -357,7 +373,11 @@
       "22.1.1": "/LLVM-22.1.1-win64.exe",
       "22.1.2": "/LLVM-22.1.2-win64.exe",
       "22.1.3": "/LLVM-22.1.3-win64.exe",
-      "22.1.4": "/LLVM-22.1.4-win64.exe"
+      "22.1.4": "/LLVM-22.1.4-win64.exe",
+      "22.1.5": "/LLVM-22.1.5-win64.exe",
+      "22.1.6": "/LLVM-22.1.6-win64.exe",
+      "22.1.7": "/LLVM-22.1.7-win64.exe",
+      "22.1.8": "/LLVM-22.1.8-win64.exe"
     }
   }
 }


### PR DESCRIPTION
Adds the 22.1 packages/installers to `assets.json`.

Closes #102.