### PR TITLE
Update actions to use NodeJS 24

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -20,11 +20,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Cache LLVM and Clang
         id: cache-llvm
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             C:/Program Files/LLVM

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install LLVM and Clang
         uses: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Arch (Ubuntu / macOS)
         if: matrix.os != 'windows-latest'


### PR DESCRIPTION
Bump third-party actions used in workflows so they run on Node.js 24,
following the deprecation announcement:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Changes:
- `actions/checkout`: v4 → v6 
- `actions/cache`: v4 → v5

Note: this PR only covers workflows under `.github/workflows/`. 
Migrating  the action runtime itself (`action.yml`'s `using: node20`) is being addressed separately in #98 / #100.